### PR TITLE
Fix key errors

### DIFF
--- a/lib/models/sharing_preferences.dart
+++ b/lib/models/sharing_preferences.dart
@@ -3,13 +3,11 @@ import 'dart:convert';
 class SharingPreferences {
   final String userId;
   final bool activeSharing;
-  final bool approvedKeys;
   final List<dynamic> sharePeriods;
 
   SharingPreferences({
     required this.userId,
     required this.activeSharing,
-    required this.approvedKeys,
     required this.sharePeriods,
   });
 
@@ -18,7 +16,6 @@ class SharingPreferences {
     return SharingPreferences(
       userId: map['userId'] as String,
       activeSharing: map['activeSharing']?.toString().toLowerCase() == 'true',
-      approvedKeys: map['approvedKeys']?.toString().toLowerCase() == 'true',
       sharePeriods: jsonDecode(map['sharePeriods'] as String) as List<dynamic>,
     );
   }
@@ -28,7 +25,6 @@ class SharingPreferences {
     return {
       'userId': userId,
       'activeSharing': activeSharing.toString(), // Store as TEXT
-      'approvedKeys': approvedKeys.toString(),   // Store as TEXT
       'sharePeriods': jsonEncode(sharePeriods),  // Encode JSON for storage
     };
   }

--- a/lib/models/user_location.dart
+++ b/lib/models/user_location.dart
@@ -8,7 +8,6 @@ class UserLocation {
   final double latitude;
   final double longitude;
   final String timestamp;
-  final Map<String, dynamic> deviceKeys;
   final String iv; // Store as a String in the database
 
   UserLocation({
@@ -16,7 +15,6 @@ class UserLocation {
     required this.latitude,
     required this.longitude,
     required this.timestamp,
-    required this.deviceKeys,
     required this.iv,
   });
 
@@ -36,7 +34,6 @@ class UserLocation {
       latitude: double.parse(decryptedLatitude),
       longitude: double.parse(decryptedLongitude),
       timestamp: map['timestamp'] as String,
-      deviceKeys: jsonDecode(map['deviceKeys'] as String),
       iv: map['iv'] as String,
     );
   }
@@ -55,7 +52,6 @@ class UserLocation {
       'latitude': encryptedLatitude,
       'longitude': encryptedLongitude,
       'timestamp': timestamp,
-      'deviceKeys': jsonEncode(deviceKeys),
       'iv': iv, // Store the IV as a string in the database
     };
   }

--- a/lib/providers/room_provider.dart
+++ b/lib/providers/room_provider.dart
@@ -610,10 +610,10 @@ class RoomProvider with ChangeNotifier {
 
   Future<void> updateRooms(LocationData position) async {
     List<Room> rooms = client.rooms;
+    await updateAllUsersDeviceKeys();
     var roomsUpdated = 0;
     for (Room room in rooms) {
       // first check all keys again to be careful
-      await updateUsersInRoomKeysStatus(room);
       var joinedMembers = room
           .getParticipants()
           .where((member) => member.membership == Membership.join)
@@ -676,51 +676,44 @@ class RoomProvider with ChangeNotifier {
     return deviceKeysMap; // Returns a map of device IDs to their key maps
   }
 
+  Future<void> updateAllUsersDeviceKeys() async {
+    final rooms = client.rooms;
+    rooms.forEach((room) async => {
+     await updateUsersInRoomKeysStatus(room)
+    });
+  }
+
   Future<void> updateUsersInRoomKeysStatus(Room room) async {
-    // TODO: this may need to be renamed as like completeUpdateDbFromRooms
     final members = room.getParticipants().where((member) => member.membership == Membership.join);
     members.forEach((member) async {
       final userDeviceKey = getUserDeviceKeys(member.id);
-      final keysEncoded = jsonEncode(userDeviceKey);
-      final hasSeenUser = await databaseService.checkIfUserHasSharedPrefs(member.id);
+      final hasSeenUser = await databaseService.checkIfUserHasDeviceKeys(member.id);
       if (!hasSeenUser) {
-        databaseService.insertUserLocation(member.id, 0.0, 0.0, "null", keysEncoded);
         databaseService.insertUserKeys(member.id, userDeviceKey);
-        databaseService.insertSharingPreferences(userId: member.id, activeSharing: true, approvedKeys: true, sharePeriods: {"":""});
-      }
-      final hasNewKeys = await userHasNewDeviceKeys(member.id, userDeviceKey);
-      if (hasNewKeys) {
-        databaseService.updateApprovedKeys(member.id, false);
       } else {
-        // do nothing
+        final hasNewKeys = await userHasNewDeviceKeys(member.id, userDeviceKey);
+        if (hasNewKeys) {
+          databaseService.updateApprovedKeys(member.id, false);
+          databaseService.insertUserKeys(member.id, userDeviceKey);
+        }
       }
     });
   }
 
   Future<void> fetchAndUpdateLocations() async {
-    // TODO: check unjoined/invited rooms
-    // currently only checks joined rooms
     await cleanRooms(); // leave rooms that are expired or empty
-    Map<String, dynamic> usersLocationAndKeysMap = {};
-
+    Map<String, dynamic> usersLocationMap = {};
     final rooms = client.rooms.where((room) => room.membership == Membership.join);
     for (Room unreadRoom in rooms) {
-      // TODO: fetch userKeys here
-      updateUsersInRoomKeysStatus(unreadRoom);
       final events = await getDecryptedRoomEvents(unreadRoom.id);
       if (events.isNotEmpty) {
         final eventLocations = await processRoomEvents(events);
         eventLocations.forEach((userId, locationData) {
-          var userDeviceKeys = getUserDeviceKeys(userId);
-          var userLocationAndKeys = {
-            ...locationData,
-            'devices': userDeviceKeys, // Add all device keys for this user
-          };
-          usersLocationAndKeysMap[userId] = userLocationAndKeys;
+          usersLocationMap[userId] = locationData;
         });
       }
     }
-    await updateUserLocationsInDatabase(usersLocationAndKeysMap);
+    await updateUserLocationsInDatabase(usersLocationMap);
     print("Emitting updates after fully updating database.");
     databaseService.emitUpdatesToAppAfterUpdatingDB(); // Update ONCE after completed fetching
   }
@@ -773,34 +766,17 @@ class RoomProvider with ChangeNotifier {
         final latitude = eventLocation.value['latitude'] as double;
         final longitude = eventLocation.value['longitude'] as double;
         final timestamp = eventLocation.value['timestamp'] as String;
-        final deviceKeys = eventLocation.value['devices'];
-
-        // Encode device keys as JSON
-        final deviceKeysJson = jsonEncode(deviceKeys);
-
         // Check if the userId already exists in the database
         final existing = await databaseService.getUserLocationById(userId);
-
-        // first check if we are tracking the,
-        final hasNewKeys = await userHasNewDeviceKeys(userId, deviceKeys);
-
         if (existing == null) {
           print("First time seeing $userId, updating user in local DB");
           // If no existing record, insert a new one
           await databaseService.insertUserLocation(
-              userId, latitude, longitude, timestamp, deviceKeysJson
+              userId, latitude, longitude, timestamp
           );
-          // if first time seeing user just create a shared prefs for them too
-          await databaseService.insertSharingPreferences(
-              userId: userId, activeSharing: true, approvedKeys: true, sharePeriods: {"":""});
         } else {
-          // If the record exists, update it
-          if (hasNewKeys) {
-            // set approved keys to false for userId
-            databaseService.updateApprovedKeys(userId, false);
-          }
           await databaseService.updateUserLocation(
-              userId, latitude, longitude, timestamp, deviceKeysJson
+              userId, latitude, longitude, timestamp
           );
         }
       }
@@ -812,9 +788,10 @@ class RoomProvider with ChangeNotifier {
   Future<bool> userHasNewDeviceKeys(String userId, Map<String, dynamic> newKeys) async {
     final curKeys = await databaseService.getDeviceKeysByUserId(userId);
     if (curKeys == null) {
+      print("curKeys is null");
+      databaseService.insertUserKeys(userId, newKeys);
       return false; // actually return false since we don't need to alert
     }
-
     for (final key in newKeys.keys) {
       if (!curKeys.containsKey(key)) {
         return true; // New key found

--- a/lib/providers/room_provider.dart
+++ b/lib/providers/room_provider.dart
@@ -627,21 +627,25 @@ class RoomProvider with ChangeNotifier {
 
       // update contacts
       else if (joinedMembers.length == 2) {
+        sendLocationEvent(room.id, position);
+        roomsUpdated += 1;
+      }
+
+        /*
         final contactsUserId = joinedMembers
             .firstWhere((member) => member.id != userId)
             .id;
         if (await databaseService.checkIfUserHasSharedPrefs(contactsUserId)) {
           if (await databaseService.getApprovedKeys(contactsUserId) == false) {
             print("$contactsUserId has new keys, not sending location and warning user");
-            // TODO: notification indicating key changes
-          } else {
-            sendLocationEvent(room.id, position);
-            roomsUpdated += 1;
+            // TODO: option to only send to approved/verified rooms
+            // right now sending regardless to prevent a standstill
+            // where nobody shares which leads to nobody verifying keys
+
           }
-        }
-      }
+          */
       else {
-        // dont update prob clean rooms?
+        // dont update and clean rooms?
       }
     }
     print("Updated a total of $roomsUpdated rooms with my location: $position");
@@ -767,9 +771,12 @@ class RoomProvider with ChangeNotifier {
 
         // Check if the userId already exists in the database
         final existing = await databaseService.getUserLocationById(userId);
+
+        // first check if we are tracking the,
         final hasNewKeys = await userHasNewDeviceKeys(userId, deviceKeys);
 
         if (existing == null) {
+          print("First time seeing $userId, updating user in local DB");
           // If no existing record, insert a new one
           await databaseService.insertUserLocation(
               userId, latitude, longitude, timestamp, deviceKeysJson

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -374,6 +374,27 @@ class DatabaseService {
     return result.isNotEmpty;
   }
 
+  Future<void> insertUserKeys(String userId, Map<String, dynamic> keysMap) async {
+    final db = await database;
+
+    // Convert the keys map to JSON string
+    final deviceKeysJson = jsonEncode(keysMap);
+
+    // Update the deviceKeys field in the UserLocations table
+    await db.update(
+      'UserLocations',
+      {
+        'deviceKeys': deviceKeysJson,
+      },
+      where: 'userId = ?',
+      whereArgs: [userId],
+    );
+
+    print('Updated deviceKeys for userId $userId');
+    _emitLocationUpdates(); // Emit updates to the stream
+  }
+
+
   void _emitLocationUpdates() async {
     final userLocations = await getUserLocations();
     _locationStreamController.add(userLocations);

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -58,18 +58,11 @@ class DatabaseService {
       latitude TEXT,
       longitude TEXT,
       timestamp TEXT,
-      deviceKeys TEXT,
       iv TEXT
     );
   ''');
     print('UserLocations table created');
 
-    // SharingPreferences DB maps all contacts/group members
-    // to a true/false activeSharing which toggles whether you send
-    // location updates, approvedKeys which is a bool that gets set to
-    // false if keys change, once manually approved in app changes to true
-    // and sharePeriods which is a JSON that tracks share windows like
-    // 5-7PM Mon-Fri, which can have multiple, etc.
 
     print('Creating SharingPreferences table');
     await db.execute('''
@@ -77,11 +70,21 @@ class DatabaseService {
       id INTEGER PRIMARY KEY AUTOINCREMENT,
       userId TEXT,
       activeSharing TEXT,       -- true/false as TEXT
-      approvedKeys TEXT,        -- true/false as TEXT
       sharePeriods TEXT         -- JSON-encoded string with sharing periods
     );
   ''');
     print('SharingPreferences table created');
+
+    print('Creating UserDeviceKeys table');
+    await db.execute('''
+    CREATE TABLE IF NOT EXISTS UserDeviceKeys (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    userId TEXT,
+    deviceKeys TEXT,
+    approvedKeys TEXT
+    );
+    ''');
+    print('UserDeviceKeys table created');
   }
 
 
@@ -107,7 +110,6 @@ class DatabaseService {
       double latitude,
       double longitude,
       String timestamp,
-      String deviceKeysJson,
       ) async {
     final db = await database;
     final encryptionKey = await _getOrCreateEncryptionKey();
@@ -121,16 +123,13 @@ class DatabaseService {
       latitude: latitude,
       longitude: longitude,
       timestamp: timestamp,
-      deviceKeys: jsonDecode(deviceKeysJson),
       iv: iv,
     );
-
     await db.insert(
       'UserLocations',
       userLocation.toMap(encryptionKey),
       conflictAlgorithm: ConflictAlgorithm.replace,
     );
-
     print('Inserting user location into DB: $userLocation');
     _emitLocationUpdates(); // Emit updates to the stream
   }
@@ -138,7 +137,6 @@ class DatabaseService {
   Future<void> insertSharingPreferences({
     required String userId,
     required bool activeSharing,
-    required bool approvedKeys,
     required Map<String, dynamic> sharePeriods, // Define share periods as a map
   }) async {
     final db = await database;
@@ -150,7 +148,6 @@ class DatabaseService {
     final sharingPreferences = {
       'userId': userId,
       'activeSharing': activeSharing ? 'true' : 'false',
-      'approvedKeys': approvedKeys ? 'true' : 'false',
       'sharePeriods': sharePeriodsJson,
     };
 
@@ -184,7 +181,6 @@ class DatabaseService {
       double latitude,
       double longitude,
       String timestamp,
-      String deviceKeysJson
       ) async {
     final db = await database;
     final encryptionKey = await _getOrCreateEncryptionKey();
@@ -210,7 +206,6 @@ class DatabaseService {
       latitude: latitude,
       longitude: longitude,
       timestamp: timestamp,
-      deviceKeys: jsonDecode(deviceKeysJson),
       iv: iv,
     );
 
@@ -306,7 +301,7 @@ class DatabaseService {
 
     // Query the database for the user location record by userId
     final result = await db.query(
-      'UserLocations',
+      'UserDeviceKeys',
       columns: ['deviceKeys'],
       where: 'userId = ?',
       whereArgs: [userId],
@@ -317,7 +312,6 @@ class DatabaseService {
       final deviceKeysJson = result.first['deviceKeys'] as String;
       return jsonDecode(deviceKeysJson) as Map<String, dynamic>;
     }
-
     // Return null if no record found for the userId
     return null;
   }
@@ -341,26 +335,28 @@ class DatabaseService {
   Future<bool?> getApprovedKeys(String userId) async {
     final db = await database;
     final result = await db.query(
-      'SharingPreferences',
+      'UserDeviceKeys',
       columns: ['approvedKeys'],
       where: 'userId = ?',
       whereArgs: [userId],
     );
-
     if (result.isNotEmpty) {
       return result.first['approvedKeys']?.toString().toLowerCase() == 'true';
     }
     return null; // Returns null if no record found for userId
   }
 
-  Future<int> updateApprovedKeys(String userId, bool approvedKeys) async {
+  Future<void> updateApprovedKeys(String userId, bool approvedKeys) async {
     final db = await database;
-    return await db.update(
-      'SharingPreferences',
+    final keys = await getDeviceKeysByUserId(userId);
+    await db.update(
+      'UserDeviceKeys',
       {'approvedKeys': approvedKeys.toString()},
       where: 'userId = ?',
       whereArgs: [userId],
     );
+
+
   }
 
   Future<bool> checkIfUserHasSharedPrefs(String userId) async {
@@ -374,24 +370,55 @@ class DatabaseService {
     return result.isNotEmpty;
   }
 
-  Future<void> insertUserKeys(String userId, Map<String, dynamic> keysMap) async {
+  Future<bool> checkIfUserHasDeviceKeys(String userId) async {
     final db = await database;
-
-    // Convert the keys map to JSON string
-    final deviceKeysJson = jsonEncode(keysMap);
-
-    // Update the deviceKeys field in the UserLocations table
-    await db.update(
-      'UserLocations',
-      {
-        'deviceKeys': deviceKeysJson,
-      },
+    final result = await db.query(
+      'UserDeviceKeys',
+      columns: ['userId'],
       where: 'userId = ?',
       whereArgs: [userId],
     );
+    return result.isNotEmpty;
+  }
 
-    print('Updated deviceKeys for userId $userId');
-    _emitLocationUpdates(); // Emit updates to the stream
+  Future<void> insertUserKeys(String userId, Map<String, dynamic> keysMap) async {
+    final db = await database;
+
+    // Convert the keys map to a JSON string
+    final deviceKeysJson = jsonEncode(keysMap);
+
+    // Check if the record exists
+    final result = await db.query(
+      'UserDeviceKeys',
+      where: 'userId = ?',
+      whereArgs: [userId],
+    );
+    print(result);
+
+    if (result.isNotEmpty) {
+      // Update existing record
+      await db.update(
+        'UserDeviceKeys',
+        {
+          'deviceKeys': deviceKeysJson,
+        },
+        where: 'userId = ?',
+        whereArgs: [userId],
+      );
+      print('Updated deviceKeys for userId $userId');
+    } else {
+      // Insert new record with approvedKeys defaulting to true
+      await db.insert(
+        'UserDeviceKeys',
+        {
+          'userId': userId,
+          'deviceKeys': deviceKeysJson,
+          'approvedKeys': "true", // Default to true when inserting
+        },
+        conflictAlgorithm: ConflictAlgorithm.replace,
+      );
+      print('Inserted new deviceKeys and approvedKeys for userId $userId');
+    }
   }
 
 

--- a/lib/widgets/contacts_subscreen.dart
+++ b/lib/widgets/contacts_subscreen.dart
@@ -65,6 +65,7 @@ class ContactsSubscreenState extends State<ContactsSubscreen> {
 
   Future<void> _fetchApprovedKeysStatus() async {
     final databaseService = Provider.of<DatabaseService>(context, listen: false);
+    final roomProvider = Provider.of<RoomProvider>(context, listen: false);
     Map<String, bool> tempApprovedKeysStatus = {};
     for (var user in _contacts) {
       bool? status = await databaseService.getApprovedKeys(user.id);
@@ -182,7 +183,6 @@ class ContactsSubscreenState extends State<ContactsSubscreen> {
           latitude: userLocationData.latitude,
           longitude: userLocationData.longitude,
           timestamp: userLocationData.timestamp,
-          deviceKeys: userLocationData.deviceKeys,
           iv: userLocationData.iv,
         ));
       } else {

--- a/lib/widgets/group_details_subscreen.dart
+++ b/lib/widgets/group_details_subscreen.dart
@@ -177,7 +177,6 @@ class _GroupDetailsSubscreenState extends State<GroupDetailsSubscreen> {
           latitude: userLocationData.latitude,
           longitude: userLocationData.longitude,
           timestamp: userLocationData.timestamp,
-          deviceKeys: userLocationData.deviceKeys,
           iv: userLocationData.iv,
         ));
       } else {

--- a/lib/widgets/user_keys_modal.dart
+++ b/lib/widgets/user_keys_modal.dart
@@ -70,8 +70,8 @@ class UserKeysModal extends StatelessWidget {
           SizedBox(height: 10),
           Text(
             approvedKeys
-                ? 'This user’s keys are verified and trusted for secure communication.'
-                : 'This user’s keys are not verified. Keys change when a user potentially logs in from a new device, or their account may have been compromised. Verify their Device ID below:',
+                ? 'This contact\'s keys are verified and trusted for secure communication.'
+                : 'This user’s keys have changed. Please verify their device IDs below. ',
             style: TextStyle(fontSize: 14),
           ),
           SizedBox(height: 10),

--- a/lib/widgets/user_keys_modal.dart
+++ b/lib/widgets/user_keys_modal.dart
@@ -20,8 +20,8 @@ class UserKeysModal extends StatelessWidget {
 
   void approveKeys(BuildContext context) async {
     final databaseService = Provider.of<DatabaseService>(context, listen: false);
-
     try {
+      print("attemping to approve keys for ${this.userId}");
       await databaseService.updateApprovedKeys(this.userId, true);
 
       // Notify the parent widget that keys were approved


### PR DESCRIPTION
Identity keys for all other contacts/group members are tracked locally on device. When there is a change it will notify the user over the contact's avatar. 

Created new table in local sqflite db for devicekeys per user.

In future, on login should request to delete old device keys associated with the user so that when verifying there aren't outdated/old unused device keys in the modal.